### PR TITLE
return more context for bulk host create

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2091,8 +2091,17 @@ class BulkHostCreateSerializer(serializers.Serializer):
 
         # This actually updates the cached "total_hosts" field on the inventory
         update_inventory_computed_fields.delay(validated_data['inventory'].id)
-        ids = [item.id for item in result]
-        return {"created": ids, "url": InventorySerializer().get_related(validated_data['inventory'])['hosts']}
+        return_keys = [k for k in BulkHostSerializer().fields.keys()] + ['id']
+        return_data = []
+        for r in result:
+            item = {k: getattr(r, k) for k in return_keys}
+            if not settings.IS_TESTING_MODE:
+                # sqlite acts different with bulk_create -- it doesn't return the id of the objects
+                # to get it, you have to do an additional query, which is not useful for our tests
+                item['url'] = reverse('api:host_detail', kwargs={'pk': r.id})
+            item['inventory'] = reverse('api:inventory_detail', kwargs={'pk': validated_data['inventory'].id})
+            return_data.append(item)
+        return return_data
 
 
 class GroupTreeSerializer(GroupSerializer):

--- a/awx/main/tests/functional/test_bulk.py
+++ b/awx/main/tests/functional/test_bulk.py
@@ -47,7 +47,7 @@ def test_bulk_host_create_num_queries(organization, inventory, post, get, user, 
         hosts = [{'name': uuid4()} for i in range(num_hosts)]
         with withAssertNumQueriesLessThan(num_queries):
             bulk_host_create_response = post(reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': hosts}, u, expect=201).data
-            assert bulk_host_create_response['created'] == len(hosts), f"unexpected number of hosts created for user {u}"
+            assert len(bulk_host_create_response) == len(hosts), f"unexpected number of hosts created for user {u}"
 
 
 @pytest.mark.django_db
@@ -80,7 +80,7 @@ def test_bulk_host_create_rbac(organization, inventory, post, get, user):
         bulk_host_create_response = post(
             reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': [{'name': f'foobar-{indx}'}]}, u, expect=201
         ).data
-        assert bulk_host_create_response['created'] == 1, f"unexpected number of hosts created for user {u}"
+        assert len(bulk_host_create_response) == 1, f"unexpected number of hosts created for user {u}"
 
     for indx, u in enumerate([member, auditor, use_inv_member]):
         bulk_host_create_response = post(
@@ -135,8 +135,7 @@ def test_bulk_job_launch_no_org_assigned(job_template, organization, inventory, 
 
 
 @pytest.mark.django_db
-def test_bulk_job_launch_multiple_org_assigned(job_template, organization, inventory, project, credential, post, get,
-                                               user):
+def test_bulk_job_launch_multiple_org_assigned(job_template, organization, inventory, project, credential, post, get, user):
     '''
     if I am part of multiple organization...
         and if I do not provide org at the launch time
@@ -156,8 +155,7 @@ def test_bulk_job_launch_multiple_org_assigned(job_template, organization, inven
 
 
 @pytest.mark.django_db
-def test_bulk_job_launch_specific_org(job_template, organization, inventory, project, credential, post, get,
-                                               user):
+def test_bulk_job_launch_specific_org(job_template, organization, inventory, project, credential, post, get, user):
     '''
     if I am part of multiple organization...
         and if I provide org at the launch time
@@ -172,12 +170,12 @@ def test_bulk_job_launch_specific_org(job_template, organization, inventory, pro
     jt.save()
     jt.execute_role.members.add(normal_user)
     bulk_job_launch_response = post(
-            reverse('api:bulk_job_launch'), {'name': 'Bulk Job Launch', 'jobs': [{'unified_job_template': jt.id}], 'organization': org1.id}, normal_user, expect=201
+        reverse('api:bulk_job_launch'), {'name': 'Bulk Job Launch', 'jobs': [{'unified_job_template': jt.id}], 'organization': org1.id}, normal_user, expect=201
     ).data
 
+
 @pytest.mark.django_db
-def test_bulk_job_launch_inventory_no_access(job_template, organization, inventory, project, credential, post, get,
-                                               user):
+def test_bulk_job_launch_inventory_no_access(job_template, organization, inventory, project, credential, post, get, user):
     '''
     if I don't have access to the inventory...
         and if I try to use it at the launch time
@@ -192,5 +190,5 @@ def test_bulk_job_launch_inventory_no_access(job_template, organization, invento
     inv = Inventory.objects.create(name='inv1', organization=org2)
     jt.execute_role.members.add(normal_user)
     bulk_job_launch_response = post(
-            reverse('api:bulk_job_launch'), {'name': 'Bulk Job Launch', 'jobs': [{'unified_job_template': jt.id, 'inventory': inv.id}]}, normal_user, expect=400
+        reverse('api:bulk_job_launch'), {'name': 'Bulk Job Launch', 'jobs': [{'unified_job_template': jt.id, 'inventory': inv.id}]}, normal_user, expect=400
     ).data

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -11,11 +11,13 @@ from datetime import timedelta
 
 
 if "pytest" in sys.modules:
+    IS_TESTING_MODE = True
     from unittest import mock
 
     with mock.patch('__main__.__builtins__.dir', return_value=[]):
         import ldap
 else:
+    IS_TESTING_MODE = False
     import ldap
 
 


### PR DESCRIPTION
now return list of minimal info about host objects

[
    {
        "name": "lakjdsafoiaweirnladlk",
        "enabled": true,
        "instance_id": "",
        "description": "",
        "variables": "",
        "id": 4593,
        "url": "/api/v2/hosts/4593/",
        "inventory": "/api/v2/inventories/1/"
    }
]

Updated tests, but needed to work around some weird behavior with sqlite. Apparently it behaves differently around assigning ID's to the result of bulk_create and that is messed up my use of `reverse` to look up the url of the hosts
