### PR TITLE
fixup return values for bulk launch and host create in awxkit

### DIFF
--- a/awxkit/awxkit/api/pages/bulk.py
+++ b/awxkit/awxkit/api/pages/bulk.py
@@ -10,3 +10,21 @@ class Bulk(base.Base):
 
 
 page.register_page([resources.bulk, (resources.bulk, 'get')], Bulk)
+
+
+class BulkJobLaunch(base.Base):
+    def post(self, payload={}):
+        result = self.connection.post(self.endpoint, payload)
+        return self.walk(result.json()['url'])
+
+
+page.register_page(resources.bulk_job_launch, BulkJobLaunch)
+
+
+class BulkHostCreate(base.Base):
+    def post(self, payload={}):
+        result = self.connection.post(self.endpoint, payload)
+        return result.json()
+
+
+page.register_page(resources.bulk_host_create, BulkHostCreate)

--- a/awxkit/awxkit/api/resources.py
+++ b/awxkit/awxkit/api/resources.py
@@ -14,6 +14,8 @@ class Resources(object):
     _auth = 'auth/'
     _authtoken = 'authtoken/'
     _bulk = 'bulk/'
+    _bulk_job_launch = 'bulk/job_launch/'
+    _bulk_host_create = 'bulk/host_create/'
     _config = 'config/'
     _config_attach = 'config/attach/'
     _credential = r'credentials/\d+/'


### PR DESCRIPTION
This allows you to do things like:
```
v2.bulk.get().job_launch.post(dict(jobs=[dict(unified_job_template=7)])).wait_until_completed()
```

and you get json results from POST to create hosts
```
In [2]: v2.bulk.get().host_create.post(dict(inventory=1, hosts=[dict(name="lkajsflksajflkjdsflksajflksd")]))
Out[2]: 
[{'name': 'lkajsflksajflkjdsflksajflksd',
  'enabled': True,
  'instance_id': '',
  'description': '',
  'variables': '',
  'id': 4594,
  'url': '/api/v2/hosts/4594/',
  'inventory': '/api/v2/inventories/1/'}]
```