### PR TITLE
HostCreate POST should return awxkit Page

### DIFF
--- a/awx_collection/meta/runtime.yml
+++ b/awx_collection/meta/runtime.yml
@@ -6,6 +6,8 @@ action_groups:
     - ad_hoc_command_cancel
     - ad_hoc_command_wait
     - application
+    - bulk_job_launch
+    - bulk_host_create
     - controller_meta
     - credential_input_source
     - credential

--- a/awx_collection/plugins/modules/bulk_job_launch.py
+++ b/awx_collection/plugins/modules/bulk_job_launch.py
@@ -116,6 +116,10 @@ options:
         - The name of the bulk job that is created
       required: False
       type: str
+    description:
+      description:
+        - Optional description of this bulk job.
+      type: str
     organization:
       description:
         - If not provided, will use the organization the user is in.
@@ -159,11 +163,6 @@ options:
       required: False
       default: 2
       type: float
-    timeout:
-      description:
-        - If waiting for the bulk job to complete this will abort after this
-          amount of seconds
-      type: int
 extends_documentation_fragment: awx.awx.auth
 '''
 

--- a/awx_collection/plugins/modules/bulk_job_launch.py
+++ b/awx_collection/plugins/modules/bulk_job_launch.py
@@ -32,11 +32,6 @@ options:
             - Job template ID to use when launching.
           type: int
           required: True
-        extra_data:
-          description:
-            - Extra variables to apply at launch time, if job template prompts for extra variables
-          type: dict
-          default: {}
         inventory:
           description:
             - Inventory ID applied as a prompt, if job template prompts for inventory
@@ -52,13 +47,19 @@ options:
           elements: int
         credentials:
           description:
-            - Credential ID applied as a prompt, if job template prompts for credentials
-          type: int
-        labels:
-          description:
-            - Label IDs to use for the job,  if job template prompts for labels
+            - Credential IDs applied as a prompt, if job template prompts for credentials
           type: list
           elements: int
+        labels:
+          description:
+            - Label IDs to use for the job, if job template prompts for labels
+          type: list
+          elements: int
+        extra_data:
+          description:
+            - Extra variables to apply at launch time, if job template prompts for extra variables
+          type: dict
+          default: {}
         diff_mode:
           description:
             - Show the changes made by Ansible tasks where supported
@@ -102,6 +103,10 @@ options:
             - Will cause the Job Template to launch a workflow if value is greater than 1.
           type: int
           default: '1'
+        identifier:
+          description:
+            - Identifier for the resulting workflow node that represents this job
+          type: str
         timeout:
           description:
             - Maximum time in seconds to wait for a job to finish (server-side), if job template prompts for timeout.
@@ -121,10 +126,6 @@ options:
       description:
         - Inventory ID to use for the jobs ran within the bulk job, only used if prompt for inventory is set.
       type: int
-    limit:
-      description:
-        - Limit to use for the bulk job.
-      type: str
     scm_branch:
       description:
         - A specific branch of the SCM project to run the template on.
@@ -135,6 +136,10 @@ options:
         - Any extra vars required to launch the job.
         - Extends the extra_data field at the individual job level.
       type: dict
+    limit:
+      description:
+        - Limit to use for the bulk job.
+      type: str
     job_tags:
       description:
         - A comma-separated list of playbook tags to specify what parts of the playbooks should be executed.

--- a/awx_collection/test/awx/test_completeness.py
+++ b/awx_collection/test/awx/test_completeness.py
@@ -44,6 +44,12 @@ no_endpoint_for_module = [
     'subscriptions',  # Subscription deals with config/subscriptions
 ]
 
+# Add modules with endpoints that are not at /api/v2
+extra_endpoints = {
+    'bulk_job_launch': '/api/v2/bulk/job_launch/',
+    'bulk_host_create': '/api/v2/bulk/host_create/',
+}
+
 # Global module parameters we can ignore
 ignore_parameters = ['state', 'new_name', 'update_secrets', 'copy_from']
 
@@ -73,6 +79,8 @@ no_api_parameter_ok = {
     'user': ['new_username', 'organization'],
     # workflow_approval parameters that do not apply when approving an approval node.
     'workflow_approval': ['action', 'interval', 'timeout', 'workflow_job_id'],
+    # bulk
+    'bulk_job_launch': ['interval', 'wait'],
 }
 
 # When this tool was created we were not feature complete. Adding something in here indicates a module
@@ -228,6 +236,10 @@ def test_completeness(collection_import, request, admin_user, job_template, exec
         user=admin_user,
         expect=None,
     )
+
+    for key, val in extra_endpoints.items():
+        endpoint_response.data[key] = val
+
     for endpoint in endpoint_response.data.keys():
         # Module names are singular and endpoints are plural so we need to convert to singular
         singular_endpoint = '{0}'.format(endpoint)

--- a/awx_collection/tests/integration/targets/bulk_host_create/main.yml
+++ b/awx_collection/tests/integration/targets/bulk_host_create/main.yml
@@ -6,7 +6,7 @@
 
 - name: Generate a unique name
   set_fact:
-    bulk_job_name: "AWX-Collection-tests-bulk_host_create-{{ test_id }}"
+    bulk_host_name: "AWX-Collection-tests-bulk_host_create-{{ test_id }}"
   
 - name: Get our collection package
   controller_meta:
@@ -19,7 +19,7 @@
 
 - name: Create an inventory
   inventory:
-    name: "{{ bulk_job_name }}"
+    name: "{{ bulk_host_name }}"
     organization: Default
     state: present
   register: inventory_result
@@ -42,3 +42,10 @@
 - assert:
     that:
       - result is not failed
+
+# cleanup
+- name: Delete inventory
+  inventory:
+    name: "{{ bulk_host_name }}"
+    organization: Default
+    state: absent

--- a/awx_collection/tests/integration/targets/bulk_job_launch/main.yml
+++ b/awx_collection/tests/integration/targets/bulk_job_launch/main.yml
@@ -61,3 +61,9 @@
       - result['job_info']['job_tags'] == "Hello World"
       - result['job_info']['inventory'] == {{ inventory_id }}
       - "result['job_info']['extra_vars'] == '{\"animal\": \"bear\", \"food\": \"carrot\"}'"
+
+# cleanup
+- name: Delete Job Template
+  job_template:
+    name: "{{ bulk_job_name }}"
+    state: absent

--- a/awxkit/awxkit/api/pages/bulk.py
+++ b/awxkit/awxkit/api/pages/bulk.py
@@ -19,12 +19,3 @@ class BulkJobLaunch(base.Base):
 
 
 page.register_page(resources.bulk_job_launch, BulkJobLaunch)
-
-
-class BulkHostCreate(base.Base):
-    def post(self, payload={}):
-        result = self.connection.post(self.endpoint, payload)
-        return result.json()
-
-
-page.register_page(resources.bulk_host_create, BulkHostCreate)

--- a/awxkit/awxkit/api/resources.py
+++ b/awxkit/awxkit/api/resources.py
@@ -15,7 +15,6 @@ class Resources(object):
     _authtoken = 'authtoken/'
     _bulk = 'bulk/'
     _bulk_job_launch = 'bulk/job_launch/'
-    _bulk_host_create = 'bulk/host_create/'
     _config = 'config/'
     _config_attach = 'config/attach/'
     _credential = r'credentials/\d+/'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Awxkit:
- use default POST for bulk host create

Collections:
- add identifier suboption for bulk job launch
- change credentials from int to list of ints
- fix completeness test
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - Collection