### PR TITLE
Make the bulk endpoint templates work in API browser

### DIFF
--- a/awx/api/templates/api/bulk_host_create_view.md
+++ b/awx/api/templates/api/bulk_host_create_view.md
@@ -4,43 +4,38 @@ This endpoint allows the client to create multiple hosts and associate them with
 
 Example:
 
-```
-{
-"inventory": 1,
-"hosts": [
-    {"name": "example1.com", "variables": "ansible_connection: local"},
-    {"name": "example2.com"}
-]
-
-}
-```
+    {
+        "inventory": 1,
+        "hosts": [
+            {"name": "example1.com", "variables": "ansible_connection: local"},
+            {"name": "example2.com"}
+        ]
+    }
 
 Return data:
 
-```commandline
-{
-    "url": "/api/v2/inventories/3/hosts/",
-    "hosts": [
-        {
-            "name": "example1.com",
-            "enabled": true,
-            "instance_id": "",
-            "description": "",
-            "variables": "ansible_connection: local",
-            "id": 1255,
-            "url": "/api/v2/hosts/1255/",
-            "inventory": "/api/v2/inventories/3/"
-        },
-        {
-            "name": "example2.com",
-            "enabled": true,
-            "instance_id": "",
-            "description": "",
-            "variables": "",
-            "id": 1256,
-            "url": "/api/v2/hosts/1256/",
-            "inventory": "/api/v2/inventories/3/"
-        }
-    ]
-}
-```
+    {
+        "url": "/api/v2/inventories/3/hosts/",
+        "hosts": [
+            {
+                "name": "example1.com",
+                "enabled": true,
+                "instance_id": "",
+                "description": "",
+                "variables": "ansible_connection: local",
+                "id": 1255,
+                "url": "/api/v2/hosts/1255/",
+                "inventory": "/api/v2/inventories/3/"
+            },
+            {
+                "name": "example2.com",
+                "enabled": true,
+                "instance_id": "",
+                "description": "",
+                "variables": "",
+                "id": 1256,
+                "url": "/api/v2/hosts/1256/",
+                "inventory": "/api/v2/inventories/3/"
+            }
+        ]
+    }

--- a/awx/api/templates/api/bulk_job_launch_view.md
+++ b/awx/api/templates/api/bulk_job_launch_view.md
@@ -4,13 +4,10 @@ This endpoint allows the client to launch multiple UnifiedJobTemplates at a time
 
 Example:
 
-```
-{
-"name": "my bulk job",
-"jobs": [
-    {"unified_job_template": 7, "inventory": 2},
-    {"unified_job_template": 7, "credentials": [3]}
-]
-
-}
-```
+    {
+        "name": "my bulk job",
+        "jobs": [
+            {"unified_job_template": 7, "inventory": 2},
+            {"unified_job_template": 7, "credentials": [3]}
+        ]
+    }

--- a/awx/api/views/bulk.py
+++ b/awx/api/views/bulk.py
@@ -6,6 +6,7 @@ from rest_framework.reverse import reverse
 from rest_framework import status
 from rest_framework.response import Response
 
+from awx.main.models import UnifiedJob, Host
 from awx.api.generics import (
     GenericAPIView,
     APIView,
@@ -17,7 +18,6 @@ from awx.api import (
 
 
 class BulkView(APIView):
-    _ignore_model_permissions = True
     permission_classes = [IsAuthenticated]
     renderer_classes = [
         renderers.BrowsableAPIRenderer,
@@ -34,8 +34,8 @@ class BulkView(APIView):
 
 
 class BulkJobLaunchView(GenericAPIView):
-    _ignore_model_permissions = True
     permission_classes = [IsAuthenticated]
+    model = UnifiedJob
     serializer_class = serializers.BulkJobLaunchSerializer
     allowed_methods = ['GET', 'POST', 'OPTIONS']
 
@@ -53,8 +53,8 @@ class BulkJobLaunchView(GenericAPIView):
 
 
 class BulkHostCreateView(GenericAPIView):
-    _ignore_model_permissions = True
     permission_classes = [IsAuthenticated]
+    model = Host
     serializer_class = serializers.BulkHostCreateSerializer
     allowed_methods = ['GET', 'POST', 'OPTIONS']
 


### PR DESCRIPTION
##### SUMMARY
I checked out this branch https://github.com/ansible/awx/pull/13462 and discovered that the API browser templated help text wasn't working. In the PR, I made several comments about the content of those templates. This PR is not making content changes, only making changes in order to get them to functionally _render_, which they were not before. So specifically, this makes it so that clicking the "?" will give me this in the 2 non-root bulk views:

![Screenshot from 2023-02-17 09-38-45](https://user-images.githubusercontent.com/1385596/219685163-6a448093-18a3-4f0c-91f0-f799c098de13.png)


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
The solution was so non-obvious that I went ahead with a new PR.

For justification of my actions, see the comments for `GenericAPIView`:

```python
class GenericAPIView(generics.GenericAPIView, APIView):
    # Base class for all model-based views.

    # Subclasses should define:
    #   model = ModelClass
    #   serializer_class = SerializerClass
```

These comments were categorically violated by these 2 bulk endpoints. A model was not specified, so the metadata logic was not working. I'm not defending that logic, it is the furthest thing from obvious, but this fixes the rendering of the help template.
