### PR TITLE
lower num jobs/hosts in tests

### DIFF
--- a/awx/main/tests/functional/test_bulk.py
+++ b/awx/main/tests/functional/test_bulk.py
@@ -10,7 +10,7 @@ from awx.main.scheduler import TaskManager
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('num_hosts, num_queries', [(9, 15), (99, 20)])
+@pytest.mark.parametrize('num_hosts, num_queries', [(1, 10), (10, 10)])
 def test_bulk_host_create_num_queries(organization, inventory, post, get, user, num_hosts, num_queries, django_assert_max_num_queries):
     '''
     If I am a...
@@ -80,7 +80,7 @@ def test_bulk_host_create_rbac(organization, inventory, post, get, user):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('num_jobs, num_queries', [(9, 30), (99, 35)])
+@pytest.mark.parametrize('num_jobs, num_queries', [(1, 25), (10, 25)])
 def test_bulk_job_launch_queries(job_template, organization, inventory, project, post, get, user, num_jobs, num_queries, django_assert_max_num_queries):
     '''
     if I have access to the unified job template


### PR DESCRIPTION
we can test query scaling at lower numbers, to reduce load in tests. We suspect this was causing some flake in the tests on PRs